### PR TITLE
Ignore White Label tests

### DIFF
--- a/Assets/Tests/PlayModeTests/WhiteLabelTests.cs
+++ b/Assets/Tests/PlayModeTests/WhiteLabelTests.cs
@@ -7,6 +7,8 @@ using LootLocker.Requests;
 
 namespace Tests
 {
+
+    [Ignore("White label has a temporary rate limit in the backend that causes all tests to fail")]
     public class WhiteLabelLoginTests
     {
         private static string WL_UNVERIFIED_USER_EMAIL = "erik+unityci@lootlocker.io";


### PR DESCRIPTION
Due to the temporary rate limit applied to white label endpoints all of those tests are failing so we ignore them.